### PR TITLE
feat(eslint/no-unused-vars): Remove caughtErrorsIgnorePattern and add destructuredArrayIgnorePattern option

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = {
             argsIgnorePattern: "^_",
             args: "after-used",
             caughtErrors: "all",
-            caughtErrorsIgnorePattern: "^_"
+            destructuredArrayIgnorePattern: "^_"
         }],
         "no-use-before-define": ["error", { functions: false }],
 


### PR DESCRIPTION
caughtErrorsIgnorePattern was removed in favor of ES2019 optional catch binding
which will be enforced in the future version of this eslint-config via https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-optional-catch-binding.md
which is tracked in Hazmi35/eslint-config#239
