### PR TITLE
fix(node): allow referencing NodeJS namespace in a type

### DIFF
--- a/conf/node.js
+++ b/conf/node.js
@@ -9,7 +9,10 @@ export default [
 
         languageOptions: {
             globals: {
-                ...globals.node
+                ...globals.node,
+
+                // TODO [2025-01-01] Find better way to fix this?
+                NodeJS: "readonly"
             },
             parserOptions: {
                 globalReturn: true


### PR DESCRIPTION
fixes #814
